### PR TITLE
Fix HPC C++ extension build and data type handling

### DIFF
--- a/src/asys_i/hpc/CMakeLists.txt
+++ b/src/asys_i/hpc/CMakeLists.txt
@@ -102,9 +102,9 @@ find_package(pybind11 CONFIG REQUIRED)
 
 set(SOURCES
 
-    cpp_ringbuffer/ring_buffer.cpp
+    src/bindings.cpp
 
-    cpp_ringbuffer/pybind_wrapper.cpp
+    cpp_ringbuffer/shm_manager.cpp
 
 )
 
@@ -112,7 +112,7 @@ set(SOURCES
 
 pybind11_add_module(
 
-    cpp_ringbuffer
+    c_ext_wrapper
 
     ${SOURCES}
 
@@ -122,13 +122,14 @@ pybind11_add_module(
 
 # Link libraries and include directories
 
-target_include_directories(cpp_ringbuffer PRIVATE
+target_include_directories(c_ext_wrapper PRIVATE
 
-    ${pybind11_INCLUDE_DIRS}
+    ${pybind11_INCLUDE_DIRS}
 
-    ${BOOST_INCLUDE_DIRS}
+    ${BOOST_INCLUDE_DIRS}
 
-    cpp_ringbuffer # To find our generated torch_dtype_codes.h
+    cpp_ringbuffer  # For shm_manager.h and torch_dtype_codes.h
+    src             # For torch_dtype_pybind_bindings.inc
 
 )
 
@@ -140,7 +141,7 @@ target_include_directories(cpp_ringbuffer PRIVATE
 
 if (UNIX AND NOT APPLE)
 
-    target_link_libraries(cpp_ringbuffer PRIVATE rt)
+    target_link_libraries(c_ext_wrapper PRIVATE rt)
 
 endif()
 
@@ -148,10 +149,10 @@ endif()
 
 # Set properties for the output file to be a standard Python extension
 
-set_target_properties(cpp_ringbuffer PROPERTIES
+set_target_properties(c_ext_wrapper PROPERTIES
 
     PREFIX ""
 
-    OUTPUT_NAME "cpp_ringbuffer"
+    OUTPUT_NAME "c_ext_wrapper"
 
 )

--- a/src/asys_i/hpc/src/bindings.cpp
+++ b/src/asys_i/hpc/src/bindings.cpp
@@ -3,6 +3,7 @@
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
 #include "cpp_ringbuffer/shm_manager.h"
+#include "torch_dtype_pybind_bindings.inc" // Generated enum bindings
 
 namespace py = pybind11;
 
@@ -75,17 +76,8 @@ private:
 PYBIND11_MODULE(c_ext_wrapper, m) {
     m.doc() = "C++ extension for A-Sys-I High-Performance Data Bus (v0.3.0)";
 
-    py::enum_<asys_i_hpc::TorchDtypeCode>(m, "TorchDtypeCode")
-        .value("UNKNOWN", asys_i_hpc::TorchDtypeCode::UNKNOWN)
-        .value("FLOAT32", asys_i_hpc::TorchDtypeCode::FLOAT32)
-        .value("FLOAT16", asys_i_hpc::TorchDtypeCode::FLOAT16)
-        .value("BFLOAT16", asys_i_hpc::TorchDtypeCode::BFLOAT16)
-        .value("INT64", asys_i_hpc::TorchDtypeCode::INT64)
-        .value("INT32", asys_i_hpc::TorchDtypeCode::INT32)
-        .value("INT16", asys_i_hpc::TorchDtypeCode::INT16)
-        .value("INT8", asys_i_hpc::TorchDtypeCode::INT8)
-        .value("UINT8", asys_i_hpc::TorchDtypeCode::UINT8)
-        .export_values();
+    // Register the TorchDtypeCode enum using the generated function
+    asys_i::hpc::register_torch_dtype_enum(m);
 
     py::class_<PacketMetadata>(m, "PacketMetadata")
         .def_readonly("shm_data_offset", &PacketMetadata::shm_data_offset)


### PR DESCRIPTION
This commit addresses several critical issues in the HPC C++ extension:

1.  **Corrected CMake Configuration:**
    *   Modified `src/asys_i/hpc/CMakeLists.txt` to compile the correct C++ binding file (`src/asys_i/hpc/src/bindings.cpp`). Previously, it pointed to non-existent source files (`cpp_ringbuffer/pybind_wrapper.cpp` and `ring_buffer.cpp`).
    *   Updated the pybind11 module name in CMake to `c_ext_wrapper` to match the definition in `bindings.cpp`.
    *   Ensured include paths in CMake are correctly set for the compiled sources.

2.  **Automated Pybind11 Enum Bindings:**
    *   The `TorchDtypeCode` enum bindings for Python in `src/asys_i/hpc/src/bindings.cpp` are now auto-generated from `DTYPE_TO_CODE_MAP` in `asys_i.common.types.py`.
    *   `scripts/generate_cpp_header.py` was extended to produce a new file (`src/asys_i/hpc/src/torch_dtype_pybind_bindings.inc`) containing this registration logic.
    *   This fixes a bug where manual bindings could become desynchronized from the C++ enum, leading to incorrect data type interpretation.

3.  **Implemented Missing `get_dtype_size_bytes` Function:**
    *   The C++ function `asys_i_hpc::get_dtype_size_bytes(TorchDtypeCode)` was missing, which would prevent the C++ extension from compiling or cause runtime errors during tensor validation in `bindings.cpp`.
    *   `scripts/generate_cpp_header.py` was further extended to generate this function within `src/asys_i/hpc/cpp_ringbuffer/torch_dtype_codes.h`. The function now correctly returns the size in bytes for each `TorchDtypeCode`.

4.  **Added Enum Synchronization Test:**
    *   A new test, `test_torch_dtype_code_synchronization`, was added to `tests/components/test_hpc_databus_wrapper.py`.
    *   This test aims to verify that the Python-exposed `TorchDtypeCode` enum (from the C++ extension) is consistent with the `DTYPE_TO_CODE_MAP`.
    *   Note: I encountered an environmental issue (lack of disk space for PyTorch) during development that blocked test execution.

These changes should ensure the HPC C++ extension (`c_ext_wrapper`) builds correctly and handles PyTorch data types reliably between Python and C++.